### PR TITLE
newauth.middleware.AuthMiddleware now supports settings.MIDDLEWARE

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -5,6 +5,7 @@ ChangeLog
 Uneleased 0.35
 =========================
 
+- 'newauth.middleware.AuthMiddleware' supports ``settings.MIDDLEWARE`` since django-1.10
 
 Release 0.34 (2016-11-25)
 =========================

--- a/newauth/middleware.py
+++ b/newauth/middleware.py
@@ -1,5 +1,16 @@
 #:coding=utf-8:
 
+from django import VERSION as DJANGO_VERSION
+from django.conf import settings
+
+if DJANGO_VERSION >= (1, 10):
+    from django.utils.deprecation import MiddlewareMixin
+else:
+    MiddlewareMixin = object
+
+from newauth.constants import DEFAULT_USER_PROPERTY
+
+
 class LazyUser(object):
     """
     Lazily creates the user object.
@@ -10,15 +21,13 @@ class LazyUser(object):
             request._newauth_cached_user = get_user_from_request(request)
         return request._newauth_cached_user
 
-class AuthMiddleware(object):
+
+class AuthMiddleware(MiddlewareMixin):
     """
     Middleware for getting the current user object
     and attaching it to the request.
     """
     def process_request(self, request):
-        from django.conf import settings
-        from newauth.constants import DEFAULT_USER_PROPERTY
-
         user_prop = getattr(settings, 'NEWAUTH_USER_PROPERTY', DEFAULT_USER_PROPERTY)
         setattr(request.__class__, user_prop, LazyUser())
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import warnings
+warnings.filterwarnings("error", module='django')
 warnings.filterwarnings("error", module='newauth')
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -15,7 +15,7 @@ DATABASES = {
     }
 }
 ROOT_URLCONF='testapp.urls'
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
detail: https://docs.djangoproject.com/ja/1.10/topics/http/middleware/#upgrading-middleware

- settings.MIDDLEWARE_CLASSES will be deprecated at Django 2.0
- settings.MIDDLEWARE is new one
- To support MIDDLEWARE, middleware implementation must be changed