### PR TITLE
 Security: strict safety check for redirect url 

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -10,6 +10,7 @@ Unrelease 0.38
 - Add feature: send logged in signal & logged out signal
 - Security: masking sensitive post parameter
 - Security: safe redirect url for open redirect possibility
+- Security: strict safety check for redirect url 
 
 Release 0.37 (2017-05-15)
 =========================

--- a/newauth/views.py
+++ b/newauth/views.py
@@ -46,10 +46,9 @@ def login(request, next_page=None,
                 # Light security check -- make sure redirect_to isn't garbage.
                 if not redirect_to or ' ' in redirect_to:
                     redirect_to = next_page or settings.LOGIN_REDIRECT_URL
-                else:
-                    # Heavier security check -- not redirected to another host
-                    if not _is_safe_url(redirect_to, request):
-                        redirect_to = next_page or settings.LOGIN_REDIRECT_URL
+                # Heavier security check -- not redirected to another host
+                elif not _is_safe_url(redirect_to, request):
+                    redirect_to = next_page or settings.LOGIN_REDIRECT_URL
                
                 # Okay, security checks complete. Log the user in.
                 auth_login(request, form.get_user())

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -197,3 +197,16 @@ class LogoutViewsTest(DjangoTestCase):
         response = self.client.get('/account/logout/?%s=%s' % (REDIRECT_FIELD_NAME, quote(redirect_url)))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Logged out page')
+
+    def test_get_logout_to_ok_redirect(self):
+        """
+        logout with HTTP GET, ok redirect.
+        """
+        redirect_url = 'http://django-newauth.com/path/to/resource/'
+        with self.settings(ALLOWED_HOSTS=['django-newauth.com']):
+            response = self.client.get(
+                '/account/logout/?%s=%s' % (REDIRECT_FIELD_NAME, quote(redirect_url)),
+                HTTP_HOST='django-newauth.com',
+            )
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response['Location'].endswith(redirect_url))


### PR DESCRIPTION
- redirect先のチェックをdjango標準のチェックに差し替えました。
- これまでは、redirect先のチェックは、独自実装によりチェックしていました。
- djangoの仕組みの上でよりHTTP_HOSTやALLOWED_HOSTを元にチェックするように修正しました。
- また、ログアウト時のリダイレクトで、問題ないホストがリダイレクト先の場合もうまくリダイレクトできない状況になっていたので合わせて修正しました。