### PR TITLE
Fixed: login_required with py3, login authentication after the second time fails.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,11 @@
 ChangeLog
 =========
 
+Unrelease 0.39
+===============
+
+- Fixed: If login_required is used with Python3, login authentication after the second time fails.
+
 Release 0.38 (2018-09-20)
 =========================
 

--- a/newauth/decorators.py
+++ b/newauth/decorators.py
@@ -42,7 +42,7 @@ def login_required(backend_list=None, login_url=None, redirect_field_name=REDIRE
     else:
         backends = get_backends(backend_list)
 
-    backend_names = map(lambda b: b[0], backends)
+    backend_names = [b[0] for b in backends]
 
     actual_decorator = user_passes_test(
         lambda u: u.is_authenticated() and (


### PR DESCRIPTION
If login_required is used with Python3, login authentication after the second time fails.

Because, the map function returns iterator object in Py3.

The following is an example of the difference in the behavior of the map function in Python2 and Python3.

# Python3

```python
>>> backends = [['backend1'], ['backend2'], ['backend3']]
>>> backend_names = map(lambda b: b[0], backends)
>>> print(list(backend_names))
['backend1', 'backend2', 'backend3']
>>> print(list(backend_names))
[]
```

# Python2

```python
>>> backends = [['backend1'], ['backend2'], ['backend3']]
>>> backend_names = map(lambda b: b[0], backends)
>>> print(list(backend_names))
['backend1', 'backend2', 'backend3']
>>> print(list(backend_names))
['backend1', 'backend2', 'backend3']
```