### PR TITLE
fixed for py3: replace __unicode__ to __str__

### DIFF
--- a/newauth/api.py
+++ b/newauth/api.py
@@ -87,7 +87,7 @@ class UserBase(models.Model):
         return self.get_display_name()
     get_display_name.short_description = _('name')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.get_display_name()
 
     class Meta:
@@ -129,7 +129,7 @@ class AnonymousUserBase(object):
     def get_real_name(self):
         return self.get_display_name()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.get_display_name()
 
 

--- a/newauth/api.py
+++ b/newauth/api.py
@@ -3,12 +3,11 @@
 """
 Alex Gaynor will kill me
 """
-from future.utils import python_2_unicode_compatible
 import hashlib
 
 from django.utils.six import iteritems, string_types
 from django.db import models
-from django.utils.encoding import smart_str
+from django.utils.encoding import python_2_unicode_compatible, smart_str
 from django.utils.lru_cache import lru_cache
 from django.utils.module_loading import import_string
 from django.core.exceptions import ImproperlyConfigured
@@ -77,8 +76,8 @@ class UserBase(models.Model):
         public pages. This method should return
         a unicode object.
         """
-        from django.utils.encoding import force_str
-        return force_str(self.pk)
+        from django.utils.encoding import force_text
+        return force_text(self.pk)
     get_display_name.short_description = _('display name')
 
     def get_real_name(self):

--- a/newauth/api.py
+++ b/newauth/api.py
@@ -3,6 +3,7 @@
 """
 Alex Gaynor will kill me
 """
+from future.utils import python_2_unicode_compatible
 import hashlib
 
 from django.utils.six import iteritems, string_types
@@ -42,6 +43,7 @@ __all__ = (
 )
 
 
+@python_2_unicode_compatible
 class UserBase(models.Model):
     """
     Base User class
@@ -96,6 +98,7 @@ class UserBase(models.Model):
         verbose_name_plural = _('users')
 
 
+@python_2_unicode_compatible
 class AnonymousUserBase(object):
     """
     A simple anonymous user.

--- a/newauth/api.py
+++ b/newauth/api.py
@@ -75,8 +75,8 @@ class UserBase(models.Model):
         public pages. This method should return
         a unicode object.
         """
-        from django.utils.encoding import force_unicode
-        return force_unicode(self.pk)
+        from django.utils.encoding import force_str
+        return force_str(self.pk)
     get_display_name.short_description = _('display name')
 
     def get_real_name(self):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup (
     packages=find_packages(),
     install_requires=[
         'Django>=1.8',
-        'future==0.17.1',
     ],
     test_suite='tests.main',
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup (
     packages=find_packages(),
     install_requires=[
         'Django>=1.8',
+        'future==0.17.1',
     ],
     test_suite='tests.main',
     zip_safe=False,


### PR DESCRIPTION
UserBaseモデルの文字列変換を py3 用に変更