### PR TITLE
Fixed: empty list returned in python3

### DIFF
--- a/newauth/api.py
+++ b/newauth/api.py
@@ -280,7 +280,8 @@ def get_backends(backend_names=None):
     if backend_names is None:
         backend_names = all_backend_names
     else:
-        backend_names = filter(lambda b: b in backend_names, all_backend_names)
+        backend_names = [backend_name for backend_name in all_backend_names
+                         if backend_name in backend_names]
 
     backends = []
     for backend_name in backend_names:


### PR DESCRIPTION
Python3 では空リストが返ってしまうので修正

## 詳細

* `backend_names` という関数の引数と filter 関数での `backend_names` という引数が干渉してしまうのか、空リストが返ってしまう。リスト内包表記で同等に表現できるので、記法を修正した。

## 備考
* 単体テストを書こうとしましたがかけてないです
* coverage的に該当の処理を通っていることを確認済みです
* ライブラリ使用側で空リストにならず意図した値が返されている、結果として `newauth.decorators.login_required` を使用した箇所で画面遷移ができることを確認済みです