### PR TITLE
Django3.2対応

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -8,7 +8,11 @@ Release 0.42 (Unreleased)
 Release 0.41 (2022-08-x)
 =========================
 
-- Fixed: Django-3.2 Support
+- Fixed: django.conf.urls.url() is deprecated. Also, path() is more concise than re_path(). Change to use path().
+- Fixed: django.shortcuts.render_to_response() is deprecated, change to use django.shortcuts.render().
+- Fixed: django.utils.translation.ugettext_lazy() is deprecated, change to use django.utils.translation.gettext_lazy().
+- Fixed: django.utils.encoding.force_text() is deprecated, change to use django.utils.encoding.force_str().
+- Fixed: Deprecated assertEquals() in unittest used by Django, changed to assertEqual().
 
 Release 0.40 (2021-12-28)
 =========================

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -5,7 +5,7 @@ ChangeLog
 Release 0.42 (Unreleased)
 =========================
 
-Release 0.41 (2022-08-x)
+Release 0.41 (2022-08-16)
 =========================
 
 - Fixed: django.conf.urls.url() is deprecated. Also, path() is more concise than re_path(). Change to use path().

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,9 +2,13 @@
 ChangeLog
 =========
 
-Release 0.41 (Unreleased)
+Release 0.42 (Unreleased)
 =========================
 
+Release 0.41 (2022-08-x)
+=========================
+
+- Fixed: Django-3.2 Support
 
 Release 0.40 (2021-12-28)
 =========================

--- a/newauth/__init__.py
+++ b/newauth/__init__.py
@@ -1,2 +1,2 @@
-VERSION_INFO = (0, 40)
+VERSION_INFO = (0, 41)
 VERSION = '.'.join(map(str, VERSION_INFO))

--- a/newauth/admin.py
+++ b/newauth/admin.py
@@ -2,7 +2,7 @@
 
 from django import forms
 from django.conf import settings
-from django.urls import re_path
+from django.urls import path
 from django.contrib import admin
 from django.http import Http404
 from django.shortcuts import redirect
@@ -126,7 +126,11 @@ class BasicUserAdmin(UserBaseAdmin):
 
     def get_urls(self):
         return [
-            re_path(r'^(.+)/password/$', self.admin_site.admin_view(self.user_change_password))
+            path(
+                '<id>/password/',
+                self.admin_site.admin_view(self.user_change_password),
+                name='auth_user_password_change'
+            )
         ] + super(BasicUserAdmin, self).get_urls()
 
     @method_decorator(sensitive_post_parameters())

--- a/newauth/admin.py
+++ b/newauth/admin.py
@@ -2,7 +2,7 @@
 
 from django import forms
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib import admin
 from django.http import Http404
 from django.shortcuts import redirect
@@ -15,7 +15,7 @@ from django.forms.models import modelform_factory
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.debug import sensitive_post_parameters
-from django.shortcuts import render_to_response, get_object_or_404
+from django.shortcuts import render, get_object_or_404
 from django.utils.decorators import method_decorator
 from django.template import RequestContext
 from django.db.transaction import atomic
@@ -126,7 +126,7 @@ class BasicUserAdmin(UserBaseAdmin):
 
     def get_urls(self):
         return [
-            url(r'^(.+)/password/$', self.admin_site.admin_view(self.user_change_password))
+            re_path(r'^(.+)/password/$', self.admin_site.admin_view(self.user_change_password))
         ] + super(BasicUserAdmin, self).get_urls()
 
     @method_decorator(sensitive_post_parameters())
@@ -170,7 +170,7 @@ class BasicUserAdmin(UserBaseAdmin):
         fieldsets = [(None, {'fields': form.base_fields.keys()})]
         adminForm = AdminForm(form, fieldsets, {})
 
-        return render_to_response(self.change_user_password_template or 'admin/newauth/basicuser/change_password.html', {
+        return render(request, self.change_user_password_template or 'admin/newauth/basicuser/change_password.html', {
             'title': _('Change password: %s') % escape(str(user)),
             'adminForm': adminForm,
             'form': form,

--- a/newauth/admin.py
+++ b/newauth/admin.py
@@ -2,7 +2,7 @@
 
 from django import forms
 from django.conf import settings
-from django.urls import path
+from django.urls import re_path
 from django.contrib import admin
 from django.http import Http404
 from django.shortcuts import redirect
@@ -126,11 +126,7 @@ class BasicUserAdmin(UserBaseAdmin):
 
     def get_urls(self):
         return [
-            path(
-                '<id>/password/',
-                self.admin_site.admin_view(self.user_change_password),
-                name='auth_user_password_change'
-            )
+            re_path(r'^(.+)/password/$', self.admin_site.admin_view(self.user_change_password))
         ] + super(BasicUserAdmin, self).get_urls()
 
     @method_decorator(sensitive_post_parameters())

--- a/newauth/admin.py
+++ b/newauth/admin.py
@@ -126,11 +126,7 @@ class BasicUserAdmin(UserBaseAdmin):
 
     def get_urls(self):
         return [
-            path(
-                '<id>/password/',
-                self.admin_site.admin_view(self.user_change_password),
-                name='auth_user_password_change'
-            )
+            path('<id>/password/', self.admin_site.admin_view(self.user_change_password))
         ] + super(BasicUserAdmin, self).get_urls()
 
     @method_decorator(sensitive_post_parameters())

--- a/newauth/api.py
+++ b/newauth/api.py
@@ -10,7 +10,7 @@ from django.db import models
 from django.utils.encoding import smart_str
 from django.utils.module_loading import import_string
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 
 from newauth.signals import (
@@ -74,8 +74,8 @@ class UserBase(models.Model):
         public pages. This method should return
         a unicode object.
         """
-        from django.utils.encoding import force_text
-        return force_text(self.pk)
+        from django.utils.encoding import force_str
+        return force_str(self.pk)
     get_display_name.short_description = _('display name')
 
     def get_real_name(self):

--- a/newauth/forms.py
+++ b/newauth/forms.py
@@ -1,6 +1,6 @@
 #:coding=utf-8:
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django import forms
 
 from newauth.api import authenticate

--- a/newauth/urls.py
+++ b/newauth/urls.py
@@ -1,11 +1,11 @@
 #:coding=utf-8:
 
-from django.conf.urls import url
+from django.urls import path
 
 from newauth.views import login, logout
 
 
 urlpatterns = [
-    url(r'^login/$', login, name='newauth_login'),
-    url(r'^logout/$', logout, name='newauth_logout'),
+    path('login/', login, name='newauth_login'),
+    path('logout/', logout, name='newauth_logout'),
 ]

--- a/newauth/views.py
+++ b/newauth/views.py
@@ -3,7 +3,7 @@
 import django
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.shortcuts import redirect, render
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.cache import never_cache
 from django.views.decorators.debug import sensitive_post_parameters

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -136,8 +136,8 @@ class LogoutTestCase(DjangoTestCase):
         
         session_key = getattr(settings, 'NEWAUTH_SESSION_KEY', DEFAULT_SESSION_KEY)
         session_data = request.session.get(session_key) or {}
-        self.assertEquals(session_data.get('uid'), 1)
-        self.assertEquals(session_data.get('bn'), 'testapp3')
+        self.assertEqual(session_data.get('uid'), 1)
+        self.assertEqual(session_data.get('bn'), 'testapp3')
         self.assertTrue(request.auth_user.is_authenticated(), "%s is not authenticated" % request.auth_user)
         self.assertTrue(isinstance(request.auth_user, TestUser3), 'User "%s" is wrong User class "%s"' % (
             request.auth_user,
@@ -155,8 +155,8 @@ class LogoutTestCase(DjangoTestCase):
         logout(request)
 
         session_data = request.session.get(session_key) or {}
-        self.assertEquals(session_data.get('uid'), None)
-        self.assertEquals(session_data.get('bn'), None)
+        self.assertEqual(session_data.get('uid'), None)
+        self.assertEqual(session_data.get('bn'), None)
         self.assertTrue(hasattr(request, 'auth_user'), 'Request has no auth_user attribute')
         self.assertTrue(request.auth_user.is_anonymous(), 'User "%s" is authenticated' % request.auth_user)
         self.assertTrue(isinstance(request.auth_user, TestAnonymousUser3), 'User "%s" is wrong AnonymousUser class "%s"' % (
@@ -189,8 +189,8 @@ class LogoutTestCase(DjangoTestCase):
 
         session_key = getattr(settings, 'NEWAUTH_SESSION_KEY', DEFAULT_SESSION_KEY)
         session_data = request.session.get(session_key) or {}
-        self.assertEquals(session_data.get('uid'), None)
-        self.assertEquals(session_data.get('bn'), None)
+        self.assertEqual(session_data.get('uid'), None)
+        self.assertEqual(session_data.get('bn'), None)
         self.assertTrue(hasattr(request, 'auth_user'), 'Request has no auth_user attribute')
         self.assertTrue(request.auth_user.is_anonymous(), 'User "%s" is authenticated' % request.auth_user)
         self.assertTrue(request.auth_user is old_anon_user, 'Anonymous User object was changed')

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -16,10 +16,10 @@ class DecoratorTest(DjangoTestCase):
 
     def test_login_required_failed(self):
         response = self.client.get("/testapp/login_required/")
-        self.assertEquals(response.status_code, 302)
-        self.assertEquals(urlparse(response.get("Location", ""))[2], settings.LOGIN_URL)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(urlparse(response.get("Location", ""))[2], settings.LOGIN_URL)
 
     def test_login_required_testapp_failed(self):
         response = self.client.get("/testapp/testapp_login_required/")
-        self.assertEquals(response.status_code, 302)
-        self.assertEquals(urlparse(response.get("Location", ""))[2], settings.LOGIN_URL)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(urlparse(response.get("Location", ""))[2], settings.LOGIN_URL)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -25,7 +25,7 @@ class LoginViewsTest(DjangoTestCase):
             'username': 'testuser',
             'password': 'password',
         })
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         self.assertTrue(response['Location'].endswith(settings.LOGIN_REDIRECT_URL))
 
     def test_login_override_redirect_url(self):
@@ -36,7 +36,7 @@ class LoginViewsTest(DjangoTestCase):
                 'username': 'testuser',
                 'password': 'password',
             })
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         self.assertTrue(response['Location'].endswith(redirect_url))
 
     def test_fail_login(self):
@@ -44,7 +44,7 @@ class LoginViewsTest(DjangoTestCase):
             'username': 'testclient',
             'password': 'bad_password',
         })
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertFormError(response, 'form', None, "Please enter a correct username and password. Note that both fields may be case-sensitive.")
 
     def test_fail_login_blank_fields(self):
@@ -53,7 +53,7 @@ class LoginViewsTest(DjangoTestCase):
             'username': '',
             'password': 'password',
         })
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertFormError(response, 'form', 'username', u'This field is required.')
 
         # blank password
@@ -61,7 +61,7 @@ class LoginViewsTest(DjangoTestCase):
             'username': 'testuser',
             'password': '',
         })
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertFormError(response, 'form', 'password', u'This field is required.')
 
     def test_bad_redirect_space(self):
@@ -72,7 +72,7 @@ class LoginViewsTest(DjangoTestCase):
             'password': 'password',
             REDIRECT_FIELD_NAME: bad_next_url,
         })
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         self.assertTrue(response['Location'].endswith(settings.LOGIN_REDIRECT_URL))
 
     def test_bad_redirect_empty(self):
@@ -83,7 +83,7 @@ class LoginViewsTest(DjangoTestCase):
             'password': 'password',
             REDIRECT_FIELD_NAME: bad_next_url,
         })
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         self.assertTrue(response['Location'].endswith(settings.LOGIN_REDIRECT_URL))
 
     def test_bad_redirect_domain(self):
@@ -95,7 +95,7 @@ class LoginViewsTest(DjangoTestCase):
                 'password': 'password',
                 REDIRECT_FIELD_NAME: bad_next_url,
             }, HTTP_HOST='django-newauth.com')
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         self.assertTrue(response['Location'].endswith(settings.LOGIN_REDIRECT_URL))
 
     def test_bad_redirect_domain_other_case(self):
@@ -107,7 +107,7 @@ class LoginViewsTest(DjangoTestCase):
                 'password': 'password',
                 REDIRECT_FIELD_NAME: bad_next_url,
             }, HTTP_HOST='example.com')
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         self.assertTrue(response['Location'].endswith(settings.LOGIN_REDIRECT_URL))
 
     def test_ok_redirect_domain(self):
@@ -120,7 +120,7 @@ class LoginViewsTest(DjangoTestCase):
                 'password': 'password',
                 REDIRECT_FIELD_NAME: next_url,
             }, HTTP_HOST='django-newauth.com')
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         self.assertTrue(response['Location'].endswith(next_url))
 
     def test_ok_redirect_domain_as_parameter(self):
@@ -132,7 +132,7 @@ class LoginViewsTest(DjangoTestCase):
                 'password': 'password',
                 REDIRECT_FIELD_NAME: ok_url,
             }, HTTP_HOST='django-newauth.com')
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         self.assertTrue(response['Location'].endswith('/some/url?param=http://example.com/'))
 
     def test_ok_redirect(self):
@@ -143,7 +143,7 @@ class LoginViewsTest(DjangoTestCase):
             'password': 'password',
             REDIRECT_FIELD_NAME: ok_url,
         })
-        self.assertEquals(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         self.assertTrue(response['Location'].endswith(ok_url))
 
 

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -11,5 +11,5 @@ def testview(request):
 urlpatterns = [
     path('account/', include('newauth.urls')),
     path('testapp/login_required/', login_required(testview)),
-    path('testapp/testapp_login_required/', login_required(["testapp"])(testview)),
+    path('testapp/testapp_login_required', login_required(["testapp"])(testview)),
 ]

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -11,5 +11,5 @@ def testview(request):
 urlpatterns = [
     path('account/', include('newauth.urls')),
     path('testapp/login_required/', login_required(testview)),
-    path('testapp/testapp_login_required', login_required(["testapp"])(testview)),
+    path('testapp/testapp_login_required/', login_required(["testapp"])(testview)),
 ]

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,7 +1,6 @@
 #:coding=utf-8:
 from django.urls import path, include
 from django.http import HttpResponse
-from newauth import views
 from newauth.decorators import login_required
 
 
@@ -10,8 +9,7 @@ def testview(request):
 
 
 urlpatterns = [
-    path('account/login/', views.login, name='newauth_login'),
-    path('account/logout/', views.logout, name='newauth_logout'),
+    path('account/', include('newauth.urls')),
     path('testapp/login_required/', login_required(testview)),
     path('testapp/testapp_login_required/', login_required(["testapp"])(testview)),
 ]

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,5 +1,5 @@
 #:coding=utf-8:
-from django.conf.urls import url, include
+from django.urls import re_path, include
 from django.http import HttpResponse
 
 from newauth.decorators import login_required
@@ -10,7 +10,7 @@ def testview(request):
 
 
 urlpatterns = [
-    url(r'^account/', include('newauth.urls')),
-    url(r'^testapp/login_required/', login_required(testview)),
-    url(r'^testapp/testapp_login_required', login_required(["testapp"])(testview)),
+    re_path(r'^account/', include('newauth.urls')),
+    re_path(r'^testapp/login_required/', login_required(testview)),
+    re_path(r'^testapp/testapp_login_required', login_required(["testapp"])(testview)),
 ]

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,7 +1,7 @@
 #:coding=utf-8:
-from django.urls import re_path, include
+from django.urls import path, include
 from django.http import HttpResponse
-
+from newauth import views
 from newauth.decorators import login_required
 
 
@@ -10,7 +10,8 @@ def testview(request):
 
 
 urlpatterns = [
-    re_path(r'^account/', include('newauth.urls')),
-    re_path(r'^testapp/login_required/', login_required(testview)),
-    re_path(r'^testapp/testapp_login_required', login_required(["testapp"])(testview)),
+    path('account/login/', views.login, name='newauth_login'),
+    path('account/logout/', views.logout, name='newauth_logout'),
+    path('testapp/login_required/', login_required(testview), name='login_required'),
+    path('testapp/testapp_login_required/', login_required(["testapp"])(testview), name='testapp_login_required'),
 ]

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,7 +1,7 @@
 #:coding=utf-8:
-from django.urls import path, include
+from django.urls import re_path, include
 from django.http import HttpResponse
-from newauth import views
+
 from newauth.decorators import login_required
 
 
@@ -10,8 +10,7 @@ def testview(request):
 
 
 urlpatterns = [
-    path('account/login/', views.login, name='newauth_login'),
-    path('account/logout/', views.logout, name='newauth_logout'),
-    path('testapp/login_required/', login_required(testview), name='login_required'),
-    path('testapp/testapp_login_required/', login_required(["testapp"])(testview), name='testapp_login_required'),
+    re_path(r'^account/', include('newauth.urls')),
+    re_path(r'^testapp/login_required/', login_required(testview)),
+    re_path(r'^testapp/testapp_login_required', login_required(["testapp"])(testview)),
 ]

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -12,6 +12,6 @@ def testview(request):
 urlpatterns = [
     path('account/login/', views.login, name='newauth_login'),
     path('account/logout/', views.logout, name='newauth_logout'),
-    path('testapp/login_required/', login_required(testview), name='login_required'),
-    path('testapp/testapp_login_required/', login_required(["testapp"])(testview), name='testapp_login_required'),
+    path('testapp/login_required/', login_required(testview)),
+    path('testapp/testapp_login_required/', login_required(["testapp"])(testview)),
 ]


### PR DESCRIPTION
メインの修正は、render_to_response メソッドと url メソッドの廃止に伴うリプレイス。

他は現時点で簡単に修正できる範囲での警告対応。